### PR TITLE
Fix index issue when rendering spinner

### DIFF
--- a/src/utils/logVariation.js
+++ b/src/utils/logVariation.js
@@ -22,7 +22,7 @@ const logVariation = () => {
       const speed = devcycleClient.variableValue(SERVICE_USER, 'togglebot-speed', 'off')
 
       const spinChars = speed === 'slow' ? "◟◜◝◞" : "◜◠◝◞◡◟"
-      const spinner = speed === 'off' ? '○' : spinChars[idx]
+      const spinner = speed === 'off' ? '○' : spinChars[idx % spinChars.length]
       idx = (idx + 1) % spinChars.length
 
       const face = wink ? '(○ ‿ ○)' : '(- ‿ ○)'


### PR DESCRIPTION
Since `spinChars` changes length for different variations it's possible that idx is out of range when the variation changes.
Fix: Use modulo when referencing the index